### PR TITLE
Change to use implementation instead of compile

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     implementation 'com.indooratlas.android:indooratlas-android-sdk:2.7.0@aar'
 
-    compile 'com.indooratlas.android:indooratlas-android-wayfinding:2.7.0@aar'
+    implementation 'com.indooratlas.android:indooratlas-android-wayfinding:2.7.0@aar'
 
     implementation 'com.karumi:dexter:4.2.0'
 


### PR DESCRIPTION
Just small improvement, I've seen that, there is `compile` that is still being used, So I changed to `implementation`